### PR TITLE
Randomise the order in which player's actions are updated - potential first turn fix

### DIFF
--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8126,13 +8126,16 @@ void CvGame::updateMoves()
 				else
 					processPlayerAutoMoves = true;
 			}
-
+			
+			// FIRST TURN FIX
+			// Generate an array of player numbers [0,1,..,MAX_PLAYERS-1]
 			size_t Oi;
 			int processOrder[MAX_PLAYERS];
 			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
 			{
 				processOrder[Oi] = Oi;
 			}
+			// Fisher-Yates shuffle that array
 			for (Oi = 0; Oi < MAX_PLAYERS - 1; Oi++) 
 			{
 			  size_t j = Oi + rand() / (RAND_MAX / (MAX_PLAYERS - Oi) + 1);
@@ -8140,7 +8143,7 @@ void CvGame::updateMoves()
 			  processOrder[j] = processOrder[Oi];
 			  processOrder[Oi] = t;
 			}
-
+			// Do the turn processing in the new random order
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
 			{
 				CvPlayer& player = GET_PLAYER((PlayerTypes)processOrder[iI]);
@@ -8368,12 +8371,15 @@ void CvGame::updateMoves()
 		if (isOption(GAMEOPTION_DYNAMIC_TURNS) || isOption(GAMEOPTION_SIMULTANEOUS_TURNS))
 		{//Activate human players who are playing simultaneous turns now that we've finished moves for the AI.
 			// KWG: This code should go into CheckPlayerTurnDeactivate
+			// FIRST TURN FIX
+			// Generate an array of player numbers [0,1,..,MAX_PLAYERS-1]
 			size_t Oi;
 			int processOrder[MAX_PLAYERS];
 			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
 			{
 				processOrder[Oi] = Oi;
 			}
+			// Fisher-Yates shuffle that array
 			for (Oi = 0; Oi < MAX_PLAYERS - 1; Oi++) 
 			{
 			  size_t j = Oi + rand() / (RAND_MAX / (MAX_PLAYERS - Oi) + 1);
@@ -8381,7 +8387,7 @@ void CvGame::updateMoves()
 			  processOrder[j] = processOrder[Oi];
 			  processOrder[Oi] = t;
 			}
-
+			// Do the turn processing in the new random order
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
 			{
 				CvPlayer& player = GET_PLAYER((PlayerTypes)processOrder[iI]);

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -8127,14 +8127,28 @@ void CvGame::updateMoves()
 					processPlayerAutoMoves = true;
 			}
 
+			size_t Oi;
+			int processOrder[MAX_PLAYERS];
+			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
+			{
+				processOrder[Oi] = Oi;
+			}
+			for (Oi = 0; Oi < MAX_PLAYERS - 1; Oi++) 
+			{
+			  size_t j = Oi + rand() / (RAND_MAX / (MAX_PLAYERS - Oi) + 1);
+			  int t = processOrder[j];
+			  processOrder[j] = processOrder[Oi];
+			  processOrder[Oi] = t;
+			}
+
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
 			{
-				CvPlayer& player = GET_PLAYER((PlayerTypes)iI);
+				CvPlayer& player = GET_PLAYER((PlayerTypes)processOrder[iI]);
 
 				player.checkInitialTurnAIProcessed();
 				if(player.isTurnActive() && player.isHuman())
 				{
-					playersToProcess.push_back(static_cast<PlayerTypes>(iI));
+					playersToProcess.push_back(static_cast<PlayerTypes>(processOrder[iI]));
 				}
 			}
 		}
@@ -8354,9 +8368,23 @@ void CvGame::updateMoves()
 		if (isOption(GAMEOPTION_DYNAMIC_TURNS) || isOption(GAMEOPTION_SIMULTANEOUS_TURNS))
 		{//Activate human players who are playing simultaneous turns now that we've finished moves for the AI.
 			// KWG: This code should go into CheckPlayerTurnDeactivate
+			size_t Oi;
+			int processOrder[MAX_PLAYERS];
+			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
+			{
+				processOrder[Oi] = Oi;
+			}
+			for (Oi = 0; Oi < MAX_PLAYERS - 1; Oi++) 
+			{
+			  size_t j = Oi + rand() / (RAND_MAX / (MAX_PLAYERS - Oi) + 1);
+			  int t = processOrder[j];
+			  processOrder[j] = processOrder[Oi];
+			  processOrder[Oi] = t;
+			}
+
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
 			{
-				CvPlayer& player = GET_PLAYER((PlayerTypes)iI);
+				CvPlayer& player = GET_PLAYER((PlayerTypes)processOrder[iI]);
 				if(!player.isTurnActive() && player.isHuman() && player.isAlive() && player.isSimultaneousTurns())
 				{
 					player.setTurnActive(true);

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8128,27 +8128,18 @@ void CvGame::updateMoves()
 			}
 			
 			// FIRST TURN FIX
-			// Generate random order using inside-out Fisher-Yates shuffle
-			// Uses Civ's built-in synchronous random number generator 
-			size_t Oi;
-			int processOrder[MAX_PLAYERS];
-			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
-			{
-				size_t j = getJonRandNum(Oi+1, "Generate Random Player Update Order");
-				if (j != Oi) {
-					processOrder[Oi] = processOrder[j];
-				}
-				processOrder[j] = Oi;
-			}
+			// Generate random order
+			int aiOrder[MAX_PLAYERS];
+			shuffleArray(aiOrder, MAX_PLAYERS, getJonRand());
 			// Do the turn processing in the new random order
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
 			{
-				CvPlayer& player = GET_PLAYER((PlayerTypes)processOrder[iI]);
+				CvPlayer& player = GET_PLAYER((PlayerTypes)aiOrder[iI]);
 
 				player.checkInitialTurnAIProcessed();
 				if(player.isTurnActive() && player.isHuman())
 				{
-					playersToProcess.push_back(static_cast<PlayerTypes>(processOrder[iI]));
+					playersToProcess.push_back(static_cast<PlayerTypes>(aiOrder[iI]));
 				}
 			}
 		}
@@ -8369,25 +8360,19 @@ void CvGame::updateMoves()
 		{//Activate human players who are playing simultaneous turns now that we've finished moves for the AI.
 			// KWG: This code should go into CheckPlayerTurnDeactivate
 			// FIRST TURN FIX
-			// Generate random order using inside-out Fisher-Yates shuffle
-			// Uses Civ's built-in synchronous random number generator 
-			size_t Oi;
-			int processOrder[MAX_PLAYERS];
-			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
-			{
-				size_t j = getJonRandNum(Oi+1, "Generate Random Player Update Order");
-				if (j != Oi) {
-					processOrder[Oi] = processOrder[j];
-				}
-				processOrder[j] = Oi;
-			}
+			// Generate random order
+			int aiOrder[MAX_PLAYERS];
+			shuffleArray(aiOrder, MAX_PLAYERS, getJonRand());
 			// Do the turn processing in the new random order
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
 			{
-				CvPlayer& player = GET_PLAYER((PlayerTypes)processOrder[iI]);
+				CvPlayer& player = GET_PLAYER((PlayerTypes)aiOrder[iI]);
 				if(!player.isTurnActive() && player.isHuman() && player.isAlive() && player.isSimultaneousTurns())
 				{
 					player.setTurnActive(true);
+					// introduce a delay when activating players so that 
+					// response times at the beginning of turns are made more fair
+					Sleep(750.0f);
 				}
 			}
 		}

--- a/CvGameCoreDLL_Expansion2/CvGame.cpp
+++ b/CvGameCoreDLL_Expansion2/CvGame.cpp
@@ -8128,20 +8128,17 @@ void CvGame::updateMoves()
 			}
 			
 			// FIRST TURN FIX
-			// Generate an array of player numbers [0,1,..,MAX_PLAYERS-1]
+			// Generate random order using inside-out Fisher-Yates shuffle
+			// Uses Civ's built-in synchronous random number generator 
 			size_t Oi;
 			int processOrder[MAX_PLAYERS];
 			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
 			{
-				processOrder[Oi] = Oi;
-			}
-			// Fisher-Yates shuffle that array
-			for (Oi = 0; Oi < MAX_PLAYERS - 1; Oi++) 
-			{
-			  size_t j = Oi + rand() / (RAND_MAX / (MAX_PLAYERS - Oi) + 1);
-			  int t = processOrder[j];
-			  processOrder[j] = processOrder[Oi];
-			  processOrder[Oi] = t;
+				size_t j = getJonRandNum(Oi+1, "Generate Random Player Update Order");
+				if (j != Oi) {
+					processOrder[Oi] = processOrder[j];
+				}
+				processOrder[j] = Oi;
 			}
 			// Do the turn processing in the new random order
 			for(iI = 0; iI < MAX_PLAYERS; iI++)
@@ -8372,20 +8369,17 @@ void CvGame::updateMoves()
 		{//Activate human players who are playing simultaneous turns now that we've finished moves for the AI.
 			// KWG: This code should go into CheckPlayerTurnDeactivate
 			// FIRST TURN FIX
-			// Generate an array of player numbers [0,1,..,MAX_PLAYERS-1]
+			// Generate random order using inside-out Fisher-Yates shuffle
+			// Uses Civ's built-in synchronous random number generator 
 			size_t Oi;
 			int processOrder[MAX_PLAYERS];
 			for (Oi = 0; Oi < MAX_PLAYERS; Oi++) 
 			{
-				processOrder[Oi] = Oi;
-			}
-			// Fisher-Yates shuffle that array
-			for (Oi = 0; Oi < MAX_PLAYERS - 1; Oi++) 
-			{
-			  size_t j = Oi + rand() / (RAND_MAX / (MAX_PLAYERS - Oi) + 1);
-			  int t = processOrder[j];
-			  processOrder[j] = processOrder[Oi];
-			  processOrder[Oi] = t;
+				size_t j = getJonRandNum(Oi+1, "Generate Random Player Update Order");
+				if (j != Oi) {
+					processOrder[Oi] = processOrder[j];
+				}
+				processOrder[j] = Oi;
 			}
 			// Do the turn processing in the new random order
 			for(iI = 0; iI < MAX_PLAYERS; iI++)


### PR DESCRIPTION
The idea behind this is to have the game process each player's actions in a different order each turn. This way first turn is randomised, and same turn wonders are allocated randomly. NOTE: this is untested - it is literally an idea that I just smacked out.
